### PR TITLE
Adding a slice object to Region Report

### DIFF
--- a/modules/Bio/EnsEMBL/Utils/IO/ReportSerializer.pm
+++ b/modules/Bio/EnsEMBL/Utils/IO/ReportSerializer.pm
@@ -72,6 +72,7 @@ my %printables = (
                     'Bio::EnsEMBL::Gene' => ['id','biotype','start','end'],
                     'Bio::EnsEMBL::Transcript' => ['id','start','end'],
                     'Bio::EnsEMBL::Translation' => ['id'],
+                    'Bio::EnsEMBL::Slice' => ['start','end','strand'],
                     'Bio::EnsEMBL::Variation::VariationFeature' => ['id','start','end','strand','seq_region_name'],
                     'Bio::EnsEMBL::Variation::StructuralVariationFeature' => ['id','start','end','strand','seq_region_name'],
                     'Bio::EnsEMBL::Funcgen::RegulatoryFeature' => ['id','start','end','strand'],


### PR DESCRIPTION
EG customer can't get a Bacteria Region Report for regions like 
Chromosome:2684204-2685233
Chromosome:2686743-2687434
They are getting  "File system error. There was an error retrieving your data from disk. Would you like to try again with different region(s)?"

Adding a slice object to the Region Report
